### PR TITLE
add alignment overload param

### DIFF
--- a/Runtime/Scripts/Controls/ImText.cs
+++ b/Runtime/Scripts/Controls/ImText.cs
@@ -46,7 +46,8 @@ namespace Imui.Controls
                                         Color32 color,
                                         ImRect rect,
                                         bool wrap = false,
-                                        ImTextOverflow overflow = ImTextOverflow.Overflow)
+                                        ImTextOverflow overflow = ImTextOverflow.Overflow,
+                                        ImAlignment alignment = default)
         {
             // (artem-s): at least try to skip costly auto-sizing
             if (gui.Canvas.Cull(rect))
@@ -55,6 +56,7 @@ namespace Imui.Controls
             }
 
             var settings = GetTextSettings(gui, wrap, overflow);
+            settings.Align = alignment;
             settings.Size = AutoSizeTextSlow(gui, text, settings, rect.Size);
             Text(gui, text, settings, color, rect);
         }


### PR DESCRIPTION
I found this necessary, and placing it last makes it a non-breaking API change more-or-less. I didn't find the addition warranted an entirely separate overload