### PR TITLE
fix: add missing preprocessor directives

### DIFF
--- a/Runtime/Scripts/Utility/ImAssert.cs
+++ b/Runtime/Scripts/Utility/ImAssert.cs
@@ -11,7 +11,9 @@ internal class ImuiAssertException: Exception
 
 internal static class ImAssert
 {
+#if UNITY_2022_2_OR_NEWER
     [HideInCallstack]
+#endif
     [Conditional("IMUI_DEBUG")]
     public static void IsTrue(bool value, string message)
     {
@@ -21,7 +23,9 @@ internal static class ImAssert
         }
     }
 
+#if UNITY_2022_2_OR_NEWER
     [HideInCallstack]
+#endif
     [Conditional("IMUI_DEBUG")]
     public static void IsFalse(bool value, string message)
     {


### PR DESCRIPTION
Adding the package to a Unity 2021 project fails because there are some preprocessor directives missing.